### PR TITLE
Per-reqest timeout option can be passed

### DIFF
--- a/lib/pensio_api/mixins/request_defaults.rb
+++ b/lib/pensio_api/mixins/request_defaults.rb
@@ -16,7 +16,7 @@ module PensioAPI
         @credentials = PensioAPI::Credentials.for(@credentials.to_sym) unless @credentials.nil? || @credentials.is_a?(PensioAPI::Credentials)
         @credentials ||= PensioAPI::Credentials.default_credentials if PensioAPI::Credentials.credentials_mode == :default || PensioAPI::Credentials.allow_defaults
         raise Errors::NoCredentials unless @credentials && @credentials.supplied?
-        
+
         self.class.base_uri @credentials.base_uri unless self.class.base_uri
 
         @response = self.class.post(path, request_options(options))
@@ -25,11 +25,14 @@ module PensioAPI
       private
 
       def request_options(options)
+        timeout = options.delete(:timeout)
         {
           basic_auth: auth,
           headers: (options.delete(:headers) || {}).merge(HEADERS),
           body: options
-        }
+        }.tap do |request_options|
+          request_options[:timeout] = timeout if timeout
+        end
       end
 
       def auth

--- a/spec/lib/pensio_api/ecommerce_spec.rb
+++ b/spec/lib/pensio_api/ecommerce_spec.rb
@@ -7,8 +7,16 @@ describe PensioAPI::Ecommerce do
   end
 
   describe '.create_payment_request' do
-    let(:response) { PensioAPI::Ecommerce.create_payment_request(reservation_arguments) }
+    let(:response) { PensioAPI::Ecommerce.create_payment_request(reservation_arguments.merge({timeout: 10})) }
     it 'returns an instance of PensioAPI::Responses::GatewayURL' do
+      expect(PensioAPI::Request).to receive(:post).with("/merchant/API/createPaymentRequest",
+        { :basic_auth=>{:username=>"test_user", :password=>"password"},
+          :headers=>{"Content-Type"=>"application/x-www-form-urlencoded; charset=utf-8"},
+          :body=>{:terminal=>"Pensio Test Terminal",
+          :shop_orderid=>"Test Payment",
+          :amount=>123.45,
+          :currency=>"eur"},
+          :timeout=>10 }).and_call_original
       expect(response).to be_an_instance_of(PensioAPI::Responses::GatewayURL)
     end
   end


### PR DESCRIPTION
Currently only default timeout is used, sometimes it's to long for some requests. Timeout option passed per-request allows better control over requests that are made.
